### PR TITLE
Fix of Issue #3: Skip NEWENTRY line when loading gene info file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,7 @@ sub-directory:
       gunzip -c data/Homo_sapiens.gene_info.gz > data/Homo_sapiens.gene_info
 
       # Call genes_load_geneinfo to populate the database:
-      python manage.py genes_load_geneinfo --geneinfo_file=data/Homo_sapiens.gene_info --taxonomy_id=9606 --systematic_col=2 --symbol_col=2
+      python manage.py genes_load_geneinfo --geneinfo_file=data/Homo_sapiens.gene_info --taxonomy_id=9606 --systematic_col=3 --symbol_col=2
 
 
 3. genes_load_uniprot.py

--- a/genes/management/commands/genes_load_geneinfo.py
+++ b/genes/management/commands/genes_load_geneinfo.py
@@ -46,7 +46,7 @@ ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
       # Call genes_load_geneinfo to populate the database:
       python manage.py genes_load_geneinfo \
 --geneinfo_file=data/Homo_sapiens.gene_info \
---taxonomy_id=9606 --systematic_col=2 --symbol_col=2
+--taxonomy_id=9606 --systematic_col=3 --symbol_col=2
 """
 
 import logging
@@ -143,6 +143,9 @@ class Command(BaseCommand):
             entrez_created = 0  # Didn't exist, added.
             for line in geneinfo_fh:
                 toks = line.strip().split('\t')
+                if toks[symb_col] == "NEWENTRY":
+                    continue;
+
                 if not (toks[0] == gi_tax_id):  # From wrong organism, skip.
                     continue
 

--- a/genes/management/commands/genes_load_geneinfo.py
+++ b/genes/management/commands/genes_load_geneinfo.py
@@ -144,6 +144,7 @@ class Command(BaseCommand):
             for line in geneinfo_fh:
                 toks = line.strip().split('\t')
                 if toks[symb_col] == "NEWENTRY":
+                    logger.info("NEWENTRY line skipped")
                     continue;
 
                 if not (toks[0] == gi_tax_id):  # From wrong organism, skip.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-genes',
-    version='0.15',
+    version='0.16',
     packages=find_packages(),
     include_package_data=True,
     license='LICENSE.txt',


### PR DESCRIPTION
This PR is to fix issue #3 and the following issue in adage-server:
https://github.com/greenelab/adage-server/issues/198

`README.rst` is generated by sphinx automatically, so you don't need to review that file (although the revision is trivial).